### PR TITLE
MainContainer should handle views with flatlist

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,6 +8,7 @@
     "christian-kohler.npm-intellisense",
     "esbenp.prettier-vscode",
     "wayou.vscode-todo-highlight",
-    "shardulm94.trailing-spaces"
+    "shardulm94.trailing-spaces",
+    "Gruntfuggly.todo-tree"
   ]
 }

--- a/app/(app)/[speaker].tsx
+++ b/app/(app)/[speaker].tsx
@@ -5,16 +5,17 @@ import StyledText from '../../components/common/StyledText';
 import MainContainer from '../../components/container/MainContainer';
 
 /**
- * TODO: speaker page
  * -  Should display information about the speaker or organizing team member
  * - should display an image, speaker/organizer badge, name of speaker/organizer, bio and twitter handle at the bottom
  */
+
+// TODO: implement speaker page
 
 const speaker = () => {
   const { id } = useSearchParams();
 
   return (
-    <MainContainer>
+    <MainContainer preset="scroll">
       <Stack.Screen
         options={{
           title: `Speaker ${id}`,

--- a/app/(app)/feedback.tsx
+++ b/app/(app)/feedback.tsx
@@ -1,5 +1,5 @@
 /**
- * TODO: feedback page
+ * TASKS:
  * Implement feedback page
  * Should include a reactions component, a textarea and button
  */
@@ -8,9 +8,11 @@ import React from 'react';
 import StyledText from '../../components/common/StyledText';
 import MainContainer from '../../components/container/MainContainer';
 
+// TODO: implement feedback page
+
 const feedback = () => {
   return (
-    <MainContainer>
+    <MainContainer preset="scroll">
       <StyledText>feedback</StyledText>
     </MainContainer>
   );

--- a/app/(app)/home/about.tsx
+++ b/app/(app)/home/about.tsx
@@ -1,10 +1,10 @@
 /**
- * TODO: about event page
- * -  implement the about page as seen in the design
  * -  should display an image, description and a grid view of organizing team, and an organizers card
  * -  consider reusing the image component that was used in the speakers list
  * -  clicking on the team member image should navigate to the [speaker] page
  */
+
+// TODO: About page - implement about event page
 
 import React from 'react';
 import StyledText from '../../../components/common/StyledText';
@@ -12,7 +12,7 @@ import MainContainer from '../../../components/container/MainContainer';
 
 const about = () => {
   return (
-    <MainContainer>
+    <MainContainer preset="scroll">
       <StyledText>about</StyledText>
     </MainContainer>
   );

--- a/app/(app)/home/feed/index.tsx
+++ b/app/(app)/home/feed/index.tsx
@@ -5,9 +5,11 @@ import StyledText from '../../../../components/common/StyledText';
 import MainContainer from '../../../../components/container/MainContainer';
 
 /**
- * TODO: Feed page
+ * TASKS:
  * - should render the feed list
  */
+
+// TODO: implement feed page
 
 export default function Page() {
   return (

--- a/app/(app)/home/main.tsx
+++ b/app/(app)/home/main.tsx
@@ -4,16 +4,17 @@ import StyledText from '../../../components/common/StyledText';
 import MainContainer from '../../../components/container/MainContainer';
 
 /**
- * TODO: Home page
  * Should display VideoPlayer component, Sessions list component, Speakers list component, Sponsors card, Organizers card
  * - implement a home page that displays all the components listed above
  * - use the components you’ve implemented in the previous tasks
  * - use dummy data for now
  */
 
+// TODO: Home page
+
 const main = () => {
   return (
-    <MainContainer>
+    <MainContainer preset="scroll">
       <StyledText title>Welcome to the DroidCon2023!</StyledText>
 
       <Link href="/speakers">

--- a/app/(app)/home/sessions/[session].tsx
+++ b/app/(app)/home/sessions/[session].tsx
@@ -4,18 +4,15 @@ import StyledText from '../../../../components/common/StyledText';
 import MainContainer from '../../../../components/container/MainContainer';
 
 /**
- * TODO: Session page
- * - should render a Days component at the top
- * - on the left render clickable text components each displaying a day
- * - on the right a switch component as shown in the design
- * - clicking on the header icons should set the list state to either collapsed or not
- * - clicking on the filter button on the header should open a modal component
+ * - should show details of the event session: speaker name, title of session, description, level, speaker's twitter handle, and a floating action button to share the session info
  */
+
+// TODO: Session page
 
 const Session = () => {
   const { id } = useSearchParams();
   return (
-    <MainContainer>
+    <MainContainer preset="scroll">
       <Stack.Screen
         options={{
           title: `Session ${id}`,

--- a/app/(app)/home/sessions/index.tsx
+++ b/app/(app)/home/sessions/index.tsx
@@ -4,8 +4,9 @@ import React from 'react';
 import StyledText from '../../../../components/common/StyledText';
 import MainContainer from '../../../../components/container/MainContainer';
 
+// TODO: ALL Sessions page
+
 /**
- * TODO: ALL Sessions page
  * -  implement a List that displays all sessions
  * - list should either be collapsible or not
  * - Session card component should be either the small card that displays time, title, description, venue and a favorite icon button
@@ -34,7 +35,7 @@ const sessions = () => {
   const router = useRouter();
 
   return (
-    <MainContainer>
+    <MainContainer preset="scroll">
       <Stack.Screen
         options={{
           title: 'Sessions',

--- a/app/(app)/speakers.tsx
+++ b/app/(app)/speakers.tsx
@@ -1,5 +1,5 @@
 /**
- * TODO: Speakers page
+ * TASK:
  * - Should display a grid view of speakers
  * - <SpeakerCard /> should be used to display each speaker
  */
@@ -20,9 +20,11 @@ const _speakers = [
   },
 ];
 
+// TODO: implement speakers page - use dummy data
+
 const speakers = () => {
   return (
-    <MainContainer>
+    <MainContainer preset="scroll">
       <Stack.Screen
         options={{
           title: 'Speakers',

--- a/components/headers/HeaderActionRight.tsx
+++ b/components/headers/HeaderActionRight.tsx
@@ -13,7 +13,7 @@ const HeaderActionRight = () => {
   };
 
   return (
-    <Row>
+    <Row style={styles.row}>
       <Row>
         <IconButton name="list-alt" isActive={false} onPress={() => router.push('/feedback')} />
         <IconButton name="view-agenda" isActive onPress={() => router.push('/feedback')} />
@@ -27,6 +27,9 @@ const HeaderActionRight = () => {
 export default HeaderActionRight;
 
 const styles = StyleSheet.create({
+  row: {
+    marginHorizontal: 16,
+  },
   gap: {
     width: 8,
   },

--- a/components/headers/MainHeader.tsx
+++ b/components/headers/MainHeader.tsx
@@ -14,7 +14,6 @@ export default MainHeader;
 
 const styles = StyleSheet.create({
   container: {
-    paddingHorizontal: 12,
     marginRight: 16,
   },
 });


### PR DESCRIPTION
Fixes #29

# Description

This change adds a `preset` prop to main cointainer:-
- when the preset is set to `scroll` the main container is wrapped in a scrollview with necessary edge paddings
- when the preset prop is omitted or set to `fixed` the default view is rendered
- this change also handles safeArea edges for iOS and paddings for Android
- the change also handles the KeyboardAvoidingView for either preset

Fixes # (29)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Maincontainer.test.tsx

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
