### PR TITLE
adjust lint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,5 +6,6 @@ module.exports = {
     '@typescript-eslint/consistent-type-imports': 'error', // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-imports.md
     'react/no-unescaped-entities': 'off', // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md
     'react/react-in-jsx-scope': 'off', // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
+    'react/no-unstable-nested-components': ['error', { allowAsProps: true }], // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unstable-nested-components.md
   },
 };

--- a/app/(app)/[speaker].tsx
+++ b/app/(app)/[speaker].tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/rules-of-hooks */
 import { Stack, useSearchParams } from 'expo-router';
 import React from 'react';
 import StyledText from '../../components/common/StyledText';
@@ -11,7 +10,7 @@ import MainContainer from '../../components/container/MainContainer';
  */
 // TODO: Use data from mock/speaker to display speaker  and mock/organizers.ts to display organizer
 
-const speaker = () => {
+const Speaker = () => {
   const { id } = useSearchParams();
 
   return (
@@ -27,4 +26,4 @@ const speaker = () => {
   );
 };
 
-export default speaker;
+export default Speaker;

--- a/app/(app)/home/_layout.tsx
+++ b/app/(app)/home/_layout.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unstable-nested-components */
 import { AntDesign, Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@react-navigation/native';
 import { Tabs } from 'expo-router';

--- a/app/(app)/home/about.tsx
+++ b/app/(app)/home/about.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unstable-nested-components */
 import { Stack } from 'expo-router';
 import React, { useState } from 'react';
 import { View } from 'react-native';

--- a/app/(app)/home/main.tsx
+++ b/app/(app)/home/main.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unstable-nested-components */
 import { useTheme } from '@react-navigation/native';
 import { Image } from 'expo-image';
 import { Stack } from 'expo-router';

--- a/app/(app)/home/sessions.tsx
+++ b/app/(app)/home/sessions.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/rules-of-hooks */
 import { Stack, useRouter } from 'expo-router';
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
@@ -35,7 +34,7 @@ const _sessions = [
   },
 ];
 
-const sessions = () => {
+const Sessions = () => {
   const router = useRouter();
 
   return (
@@ -62,7 +61,7 @@ const sessions = () => {
   );
 };
 
-export default sessions;
+export default Sessions;
 
 const styles = StyleSheet.create({
   main: {

--- a/app/(app)/session/[session].tsx
+++ b/app/(app)/session/[session].tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unstable-nested-components */
 import { AntDesign } from '@expo/vector-icons';
 import { useTheme } from '@react-navigation/native';
 import { Stack, useRouter, useSearchParams } from 'expo-router';

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { Slot, SplashScreen } from 'expo-router';
@@ -18,29 +17,29 @@ export default () => {
   const [theme, setTheme] = useState({ mode: Appearance.getColorScheme() });
   const [isReady, setIsReady] = useState(false);
 
-  const updateTheme = (newTheme: Theme) => {
-    let mode: ColorSchemeName;
-    if (!newTheme) {
-      mode = theme.mode === 'dark' ? 'light' : 'dark';
-      newTheme = { mode, system: false };
-    } else {
-      if (newTheme.system) {
-        mode = Appearance.getColorScheme();
-        newTheme = { ...newTheme, mode };
-      } else {
-        newTheme = { ...newTheme, system: false };
-      }
-    }
-    setTheme(newTheme);
-  };
-
   useEffect(() => {
+    const updateTheme = (newTheme: Theme) => {
+      let mode: ColorSchemeName;
+      if (!newTheme) {
+        mode = theme.mode === 'dark' ? 'light' : 'dark';
+        newTheme = { mode, system: false };
+      } else {
+        if (newTheme.system) {
+          mode = Appearance.getColorScheme();
+          newTheme = { ...newTheme, mode };
+        } else {
+          newTheme = { ...newTheme, system: false };
+        }
+      }
+      setTheme(newTheme);
+    };
+
     // if the theme of the device changes, update the theme
     Appearance.addChangeListener(({ colorScheme }) => {
       updateTheme({ mode: colorScheme, system: true });
       setTheme({ mode: colorScheme });
     });
-  }, []);
+  }, [theme.mode]);
 
   const [fontsLoaded] = useFonts(customFontsToLoad);
 

--- a/context/auth.tsx
+++ b/context/auth.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import { useAsyncStorage } from '@react-native-async-storage/async-storage';
 import { createContext, useContext, useEffect, useState } from 'react';
 
@@ -33,6 +32,13 @@ export const AuthProvider = ({ children }: ProviderProps) => {
         setUser(JSON.parse(data));
       }
     });
+    /**
+     * Reason: The `useAsyncStorage` "experimental" hook is not memoized and always returns new functions
+     * which causes an infinite loop when `getItem` is used as a dependency in `useEffect`.
+     * Disabling the check here should be fine since we only want to fetch the data from async storage once
+     * and there is no need to synchronize the data with our state.
+     */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (


### PR DESCRIPTION
# Description

This PR is a chore PR to adjust some lint rules that are reporting false positives or are reporting valid problems that we should fix.

1. We have disabled the `react/no-unstable-nested-components` eslint rule in 4 files now and in all those cases, eslint is reporting false positives. This PR adjusts the rule globally to not report false positives in those cases. Component creation inside component props is fine as long as the components are called in the receiving component and not used as elements.

2. I have re-written 2 component names to start with an uppercase letter and we therefore do not need to shut down the `react-hooks/rules-of-hooks` for warning us about a valid problem.

3. I have re-written one `useEffect` to pass the correct dependencies to the hook. This is a valid problem and we should not shut down the rule.

4. I have added a reason why we have to disable exhaustive deps check in one `useEffect` hook and moved the  eslint disable comment to the specific line where it is needed instead of disabling the rule for the whole file.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

N/A

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
